### PR TITLE
Remove undefined variable workaround

### DIFF
--- a/libpdfium.spec
+++ b/libpdfium.spec
@@ -114,9 +114,6 @@ touch build/config/gclient_args.gni
 # Don't build test fonts, the fonts are required for embedded tests.
 sed -i '/third_party\/test_fonts/d' testing/BUILD.gn
 
-# Workaround for 'Undefined identifier'
-sed -i 's/use_remoteexec/false/' build/config/linux/pkg_config.gni
-
 # Custom flavor of GCC toolchain that passes CFLAGS, CXXFLAGS, etc.
 mkdir -p build/toolchain/linux/passflags
 cp %{SOURCE11} build/toolchain/linux/passflags/BUILD.gn


### PR DESCRIPTION
With pdfium 7049, it seems that there is no more `use_remoteexec` in `build/config/linux/pkg_config.gni`, so this sed command is a no-op.